### PR TITLE
Add support for non-interpolated images (#18)

### DIFF
--- a/Source/OxyPlot.Avalonia/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Avalonia/CanvasRenderContext.cs
@@ -627,6 +627,15 @@ namespace OxyPlot.Avalonia
             //// alternative: image.RenderTransform = new TranslateTransform(destX, destY);
 
             image.Source = bitmapChain;
+
+            if (interpolate)
+            {
+                RenderOptions.SetBitmapInterpolationMode(image, global::Avalonia.Visuals.Media.Imaging.BitmapInterpolationMode.LowQuality);
+            }
+            else
+            {
+                RenderOptions.SetBitmapInterpolationMode(image, global::Avalonia.Visuals.Media.Imaging.BitmapInterpolationMode.Default);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #18 by adding support for the `interpolate` parameter of `CanvasRenderContext.DrawImage`.

Uses Avalonia's `Default` interpolation for non-interpolated images, and `LowQuality` for interpolated images (which was the default value before this PR).

Interpolated heatmap example:
![image](https://user-images.githubusercontent.com/5646475/82908607-208cda00-9f60-11ea-91e9-c7ba1714bece.png)

new non-interpolated heatmap example:
![image](https://user-images.githubusercontent.com/5646475/82908641-2d113280-9f60-11ea-89a4-e70bceb4cfd5.png)