### PR TITLE
Use PackageLicenseExpression

### DIFF
--- a/Source/OxyPlot.Avalonia/OxyPlot.Avalonia.csproj
+++ b/Source/OxyPlot.Avalonia/OxyPlot.Avalonia.csproj
@@ -4,7 +4,7 @@
     <PackageId>OxyPlot.Avalonia</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>OxyPlot is a plotting library for .NET. This is a support library for OxyPlot to work with AvaloniaUI.</Description>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/oxyplot/oxyplot-avalonia/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>OxyPlot contributors</Copyright>
     <PackageProjectUrl>http://oxyplot.org/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/oxyplot/oxyplot/develop/Icons/OxyPlot_128.png</PackageIconUrl>


### PR DESCRIPTION
This PR updates the `PackageLicenseExpression` property in the `csproj` file of `OxyPlot.Avalonia`. However, the main purpose of this pull request is to see if we've set up the CD correctly, and triggering the build via a PR won't cause an unstable package version to get published.