### PR TITLE
Update Avalonia from 0.10.0-rc1 to 0.10.0

### DIFF
--- a/Source/Examples/Avalonia/AvaloniaExamples/AvaloniaExamples.csproj
+++ b/Source/Examples/Avalonia/AvaloniaExamples/AvaloniaExamples.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />
     <ProjectReference Include="..\..\..\OxyPlot.Avalonia\OxyPlot.Avalonia.csproj" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-rc1" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
   </ItemGroup>
 </Project>

--- a/Source/Examples/Avalonia/ExampleBrowser/ExampleBrowser.csproj
+++ b/Source/Examples/Avalonia/ExampleBrowser/ExampleBrowser.csproj
@@ -12,8 +12,8 @@
     </AvaloniaResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-rc1" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
     <PackageReference Include="OxyPlot.ExampleLibrary" Version="2.0.0" />
   </ItemGroup>

--- a/Source/Examples/Avalonia/MemoryTest/MemoryTest.csproj
+++ b/Source/Examples/Avalonia/MemoryTest/MemoryTest.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />
     <ProjectReference Include="..\..\..\OxyPlot.Avalonia\OxyPlot.Avalonia.csproj" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-rc1" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
   </ItemGroup>
 </Project>

--- a/Source/Examples/Avalonia/SimpleDemo/SimpleDemo.csproj
+++ b/Source/Examples/Avalonia/SimpleDemo/SimpleDemo.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />
     <ProjectReference Include="..\..\..\OxyPlot.Avalonia\OxyPlot.Avalonia.csproj" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-rc1" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-rc1" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
   </ItemGroup>
 </Project>

--- a/Source/OxyPlot.Avalonia/OxyPlot.Avalonia.csproj
+++ b/Source/OxyPlot.Avalonia/OxyPlot.Avalonia.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.xaml;Assets\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
-    <PackageReference Include="Avalonia" Version="0.10.0-rc1" />
+    <PackageReference Include="Avalonia" Version="0.10.0" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The release of Avalonia 0.10.0 was about two months ago; can this be updated + new oxyplot-avalonia nuget packages published?
I got weird missing-method-exception errors when using the most recent oxyplot-avalonia nuget packge inside an empty Avalonia Desktop application that uses version 0.10.0. Hopefully an update to the exact same Avalonia will cure these problems.