### PR TITLE
Hack to fix selection issue in Example Browser

### DIFF
--- a/Source/Examples/Avalonia/ExampleBrowser/MainViewModel.cs
+++ b/Source/Examples/Avalonia/ExampleBrowser/MainViewModel.cs
@@ -58,6 +58,12 @@ namespace ExampleBrowser
             get => example;
             set
             {
+                if (value == null)
+                {
+                    // many listboxes are bound to this, so ignore null assignments and hope that doesn't break anything
+                    return;
+                }
+
                 if (example != value)
                 {
                     example = value;


### PR DESCRIPTION
Fixes the issue with selection not working properly between ListBoxes.

This is a hack to stop the ListBoxes setting the selected example to `null` when they 'lose' the selection.