### PR TITLE
Fix for #44 - Resolution property is ignored

### DIFF
--- a/Source/OxyPlot.Avalonia/PngExporter.cs
+++ b/Source/OxyPlot.Avalonia/PngExporter.cs
@@ -118,7 +118,7 @@ namespace OxyPlot.Avalonia
             canvas.Measure(new Size(canvas.Width, canvas.Height));
             canvas.Arrange(new Rect(0, 0, canvas.Width, canvas.Height));
 
-            var bmp = new RenderTargetBitmap(new PixelSize(Width, Height));
+            var bmp = new RenderTargetBitmap(new PixelSize(Width, Height), new Vector(Resolution, Resolution));
             bmp.Render(canvas);
             return bmp;
         }


### PR DESCRIPTION
The `Resolution` property was not being considered at the very end.
For example, if one doubles the `Width`, `Height`, and `Resolution` (to 1400x800 at 196ppi), the output PNG would be 1400x800, but the rendered chart would be 700x400 in the top-left corner of the PNG (with the rest transparent).