### PR TITLE
Fix invalidation on Avalonia

### DIFF
--- a/Source/OxyPlot.Avalonia/PlotBase.cs
+++ b/Source/OxyPlot.Avalonia/PlotBase.cs
@@ -231,6 +231,9 @@ namespace OxyPlot.Avalonia
         {
             // perform update on UI thread
             var updateState = updateData ? 2 : 1;
+            
+            Interlocked.Exchange(ref isUpdateRequired, 0);
+            
             int currentState = isUpdateRequired;
 
             while (currentState < updateState)


### PR DESCRIPTION
Currently invalidation only works the first time, after that, the update will not work when the Model binding changes.

```
<oxy:PlotView Name="PlotView" Model="{Binding PlotViewModel}"/>
```

works the first time:

then set to null, then set to a new plot, invalidation no longer occurrs.

Fixed by using Interlocked.Exchange to reset the isUpdateRequired.