### PR TITLE
Fix invalidation after hidden

### DIFF
--- a/Source/OxyPlot.Avalonia/PlotBase.cs
+++ b/Source/OxyPlot.Avalonia/PlotBase.cs
@@ -237,7 +237,6 @@ namespace OxyPlot.Avalonia
             {
                 if (Interlocked.CompareExchange(ref isUpdateRequired, updateState, currentState) == currentState)
                 {
-                    isUpdateRequired = updateState;
                     BeginInvoke(() => UpdateModel(updateData));
                     break;
                 }
@@ -394,6 +393,7 @@ namespace OxyPlot.Avalonia
         {
             if (Width <= 0 || Height <= 0 || ActualModel == null)
             {
+                isUpdateRequired = 0;
                 return;
             }
 
@@ -403,7 +403,7 @@ namespace OxyPlot.Avalonia
 
                 if (updateState > 0)
                 {
-                    ((IPlotModel)ActualModel).Update(updateState == 2);
+                    ((IPlotModel)ActualModel).Update(updateState == 2 || updateData);
                 }
             }
 
@@ -413,7 +413,6 @@ namespace OxyPlot.Avalonia
                 // After the invalidation, the element will have its layout updated,
                 // which will occur asynchronously unless subsequently forced by UpdateLayout.
                 BeginInvoke(InvalidateArrange);
-                BeginInvoke(InvalidateVisual);
             }
 
         }


### PR DESCRIPTION
Fixes invalidation of plots that have been hidden or otherwise not rendered.

Hopefully also addresses issue observed in https://github.com/oxyplot/oxyplot-avalonia/pull/52

Originally implemented as part of effort to port to Avalonia11.