### PR TITLE
added support for avalonia 12

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <AvaloniaVersion>11.0.0</AvaloniaVersion>
-        <OxyPlotCoreVersion>2.1.2</OxyPlotCoreVersion>
+        <AvaloniaVersion>12.0.2</AvaloniaVersion>
+        <OxyPlotCoreVersion>2.2.0</OxyPlotCoreVersion>
     </PropertyGroup>
 </Project>

--- a/Source/Examples/Avalonia/AvaloniaExamples/App.axaml.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/App.axaml.cs
@@ -33,10 +33,10 @@ namespace AvaloniaExamples
         public static AppBuilder BuildAvaloniaApp()
         {
             OxyPlotModule.EnsureLoaded();
-            var builder = AppBuilder.Configure<App>().UseSkia()
-                .UsePlatformDetect()
+            var builder = AppBuilder.Configure<App>()
+                .UsePlatformDetect();
 #if DEBUG
-                .LogToTrace();
+            builder.LogToTrace();
 #endif
             return builder;
         }

--- a/Source/Examples/Avalonia/AvaloniaExamples/App.axaml.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/App.axaml.cs
@@ -33,11 +33,12 @@ namespace AvaloniaExamples
         public static AppBuilder BuildAvaloniaApp()
         {
             OxyPlotModule.EnsureLoaded();
-            return AppBuilder.Configure<App>().UseSkia()
+            var builder = AppBuilder.Configure<App>().UseSkia()
                 .UsePlatformDetect()
 #if DEBUG
                 .LogToTrace();
 #endif
+            return builder;
         }
 
         public static void Main(string[] args)

--- a/Source/Examples/Avalonia/AvaloniaExamples/App.axaml.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/App.axaml.cs
@@ -12,37 +12,37 @@ namespace AvaloniaExamples
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
-            base.Initialize();
+#if DEBUG
+    this.AttachDeveloperTools();
+#endif
         }
 
         public override void OnFrameworkInitializationCompleted()
         {
-            if (!(ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop))
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                throw new PlatformNotSupportedException();
+                desktop.MainWindow = new MainWindow();
             }
-
-            desktop.MainWindow = new MainWindow();
 
             base.OnFrameworkInitializationCompleted();
         }
+    }
 
-        static void Main(string[] args)
+    public class Program
+    {
+        public static AppBuilder BuildAvaloniaApp()
         {
             OxyPlotModule.EnsureLoaded();
-            AppBuilder.Configure<App>()
+            return AppBuilder.Configure<App>().UseSkia()
                 .UsePlatformDetect()
 #if DEBUG
-                .LogToTrace()
+                .LogToTrace();
 #endif
-                .StartWithClassicDesktopLifetime(args);
         }
 
-        public static void AttachDevTools(Window window)
+        public static void Main(string[] args)
         {
-#if DEBUG
-			DevToolsExtensions.AttachDevTools(window);
-#endif
-		}
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        }
     }
 }

--- a/Source/Examples/Avalonia/AvaloniaExamples/AvaloniaExamples.csproj
+++ b/Source/Examples/Avalonia/AvaloniaExamples/AvaloniaExamples.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>WinExe</OutputType>
+    <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup> 
   <ItemGroup>
     <AvaloniaResource Include="Images\*" />
     <None Remove="Examples\AlignedAxesDemo\MainWindow.xaml" />
     <AvaloniaXaml Include="Examples\AlignedAxesDemo\MainWindow.xaml" />
-    <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <ProjectReference Include="..\..\..\OxyPlot.Avalonia\OxyPlot.Avalonia.csproj" />
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Simple" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/Source/Examples/Avalonia/AvaloniaExamples/Examples/AnimationsDemo/MainWindow.axaml.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Examples/AnimationsDemo/MainWindow.axaml.cs
@@ -22,7 +22,6 @@ namespace AvaloniaExamples.Examples.AnimationsDemo
         public MainWindow()
         {
             this.InitializeComponent();
-            App.AttachDevTools(this);
         }
 
         private void InitializeComponent()

--- a/Source/Examples/Avalonia/AvaloniaExamples/Examples/BarSeriesDemo/MainWindow.axaml.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Examples/BarSeriesDemo/MainWindow.axaml.cs
@@ -50,8 +50,6 @@ namespace AvaloniaExamples.Examples.BarSeriesDemo
             this.DataContext = new { Model1 = tmp, Items = items };
 
             this.InitializeComponent();
-
-            App.AttachDevTools(this);
         }
 
         private void InitializeComponent()

--- a/Source/Examples/Avalonia/AvaloniaExamples/Examples/DataTemplateDemo/PlotViewDataTemplateWindow.axaml.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Examples/DataTemplateDemo/PlotViewDataTemplateWindow.axaml.cs
@@ -43,7 +43,6 @@ namespace AvaloniaExamples.Examples.DataTemplateDemo
         private void InitializeComponent()
         {
             Avalonia.Markup.Xaml.AvaloniaXamlLoader.Load(this);
-            App.AttachDevTools(this);
         }
 
         private static Random r = new Random(13);

--- a/Source/Examples/Avalonia/AvaloniaExamples/Examples/UserControlDemo/MainWindow.axaml.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Examples/UserControlDemo/MainWindow.axaml.cs
@@ -23,7 +23,6 @@ namespace AvaloniaExamples.Examples.UserControlDemo
         {
             this.InitializeComponent();
             this.DataContext = new { Model1 = new ViewModel { Title = "Plot1" }, Model2 = new ViewModel { Title = "Plot2" } };
-            App.AttachDevTools(this);
         }
 
         private void InitializeComponent()

--- a/Source/Examples/Avalonia/AvaloniaExamples/Examples/UserControlDemo/MainWindow2.axaml.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/Examples/UserControlDemo/MainWindow2.axaml.cs
@@ -24,7 +24,6 @@ namespace AvaloniaExamples.Examples.UserControlDemo
         {
             this.InitializeComponent();
             this.DataContext = new { Models = new List<ViewModel> { new ViewModel { Title = "Plot1" }, new ViewModel { Title = "Plot2" } } };
-            App.AttachDevTools(this);
         }
 
         private void InitializeComponent()

--- a/Source/Examples/Avalonia/AvaloniaExamples/MainWindow.axaml.cs
+++ b/Source/Examples/Avalonia/AvaloniaExamples/MainWindow.axaml.cs
@@ -19,7 +19,6 @@ namespace AvaloniaExamples
     using Avalonia;
     using Avalonia.Controls;
     using Avalonia.Markup.Xaml;
-    using Avalonia.Diagnostics;
     using Avalonia.Interactivity;
 
     /// <summary>
@@ -35,7 +34,6 @@ namespace AvaloniaExamples
             InitializeComponent();
             ListBox.ItemsSource = this.Examples = this.GetExamples(this.GetType().Assembly).OrderBy(e => e.Title).ToArray();
             this.DataContext = this;
-			DevToolsExtensions.AttachDevTools(this);
 		}
 
         private void InitializeComponent()

--- a/Source/Examples/Avalonia/ExampleBrowser/App.axaml.cs
+++ b/Source/Examples/Avalonia/ExampleBrowser/App.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 
@@ -9,6 +10,9 @@ namespace ExampleBrowser
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
+#if DEBUG
+    this.AttachDeveloperTools();
+#endif
         }
 
         public override void OnFrameworkInitializationCompleted()

--- a/Source/Examples/Avalonia/ExampleBrowser/ExampleBrowser.csproj
+++ b/Source/Examples/Avalonia/ExampleBrowser/ExampleBrowser.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup> 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Simple" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
     <PackageReference Include="OxyPlot.Core" Version="$(OxyPlotCoreVersion)" />
     <PackageReference Include="OxyPlot.ExampleLibrary" Version="$(OxyPlotCoreVersion)" />
   </ItemGroup>

--- a/Source/Examples/Avalonia/ExampleBrowser/MainWindow.axaml
+++ b/Source/Examples/Avalonia/ExampleBrowser/MainWindow.axaml
@@ -7,6 +7,7 @@
         xmlns:exampleBrowser="clr-namespace:ExampleBrowser;assembly=ExampleBrowser"
         xmlns:exampleLibrary="clr-namespace:ExampleLibrary;assembly=ExampleLibrary"
         x:Class="ExampleBrowser.MainWindow"
+        x:DataType="exampleBrowser:MainViewModel"
         Title="Example Browser">
     <Window.DataContext>
       <exampleBrowser:MainViewModel />

--- a/Source/Examples/Avalonia/ExampleBrowser/MainWindow.axaml.cs
+++ b/Source/Examples/Avalonia/ExampleBrowser/MainWindow.axaml.cs
@@ -9,9 +9,6 @@ namespace ExampleBrowser
         public MainWindow()
         {
             InitializeComponent();
-#if DEBUG
-            this.AttachDevTools();
-#endif
         }
 
         private void InitializeComponent()

--- a/Source/Examples/Avalonia/MemoryTest/App.axaml.cs
+++ b/Source/Examples/Avalonia/MemoryTest/App.axaml.cs
@@ -13,37 +13,37 @@ namespace MemoryTest
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
-            base.Initialize();
+#if DEBUG
+    this.AttachDeveloperTools();
+#endif
         }
 
         public override void OnFrameworkInitializationCompleted()
         {
-            if (!(ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop))
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                throw new PlatformNotSupportedException();
+                desktop.MainWindow = new MainWindow();
             }
-
-            desktop.MainWindow = new MainWindow();
 
             base.OnFrameworkInitializationCompleted();
         }
+    }
 
-        static void Main(string[] args)
+    public class Program
+    {
+        public static AppBuilder BuildAvaloniaApp()
         {
             OxyPlotModule.EnsureLoaded();
-            AppBuilder.Configure<App>()
+            return AppBuilder.Configure<App>()
                 .UsePlatformDetect()
 #if DEBUG
-                .LogToTrace()
+                .LogToTrace();
 #endif
-                .StartWithClassicDesktopLifetime(args);
         }
 
-        public static void AttachDevTools(Window window)
+        public static void Main(string[] args)
         {
-#if DEBUG
-			DevToolsExtensions.AttachDevTools(window);
-#endif
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }
     }
 }

--- a/Source/Examples/Avalonia/MemoryTest/App.axaml.cs
+++ b/Source/Examples/Avalonia/MemoryTest/App.axaml.cs
@@ -35,9 +35,9 @@ namespace MemoryTest
         {
             OxyPlotModule.EnsureLoaded();
             var builder = AppBuilder.Configure<App>()
-                .UsePlatformDetect()
+                .UsePlatformDetect();
 #if DEBUG
-                .LogToTrace();
+            builder.LogToTrace();
 #endif
             return builder;
         }

--- a/Source/Examples/Avalonia/MemoryTest/App.axaml.cs
+++ b/Source/Examples/Avalonia/MemoryTest/App.axaml.cs
@@ -34,11 +34,12 @@ namespace MemoryTest
         public static AppBuilder BuildAvaloniaApp()
         {
             OxyPlotModule.EnsureLoaded();
-            return AppBuilder.Configure<App>()
+            var builder = AppBuilder.Configure<App>()
                 .UsePlatformDetect()
 #if DEBUG
                 .LogToTrace();
 #endif
+            return builder;
         }
 
         public static void Main(string[] args)

--- a/Source/Examples/Avalonia/MemoryTest/MainWindow.axaml.cs
+++ b/Source/Examples/Avalonia/MemoryTest/MainWindow.axaml.cs
@@ -8,7 +8,6 @@ namespace MemoryTest
         public MainWindow()
         {
             this.InitializeComponent();
-            App.AttachDevTools(this);
         }
 
         private void InitializeComponent()

--- a/Source/Examples/Avalonia/MemoryTest/MemoryTest.csproj
+++ b/Source/Examples/Avalonia/MemoryTest/MemoryTest.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup> 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <ProjectReference Include="..\..\..\OxyPlot.Avalonia\OxyPlot.Avalonia.csproj" />
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Simple" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/Source/Examples/Avalonia/MemoryTest/Window1.axaml
+++ b/Source/Examples/Avalonia/MemoryTest/Window1.axaml
@@ -2,6 +2,8 @@
         xmlns:oxy="http://oxyplot.org/avalonia" 
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="MemoryTest.Window1"
+        xmlns:local="clr-namespace:MemoryTest"
+        x:DataType="local:Window1"
         MinWidth="500" MinHeight="300">
   <Grid>
     <oxy:PlotView Model="{Binding .}"/>

--- a/Source/Examples/Avalonia/MemoryTest/Window1.axaml.cs
+++ b/Source/Examples/Avalonia/MemoryTest/Window1.axaml.cs
@@ -17,8 +17,6 @@ namespace MemoryTest
             DataContext = Model;
 
             InitializeComponent();
-
-            App.AttachDevTools(this);
         }
 
         private void InitializeComponent()

--- a/Source/Examples/Avalonia/MemoryTest/Window2.axaml
+++ b/Source/Examples/Avalonia/MemoryTest/Window2.axaml
@@ -2,6 +2,8 @@
         xmlns:oxy="http://oxyplot.org/avalonia"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="MemoryTest.Window2"
+        xmlns:local="clr-namespace:MemoryTest"
+        x:DataType="local:Window2"
         MinWidth="500" MinHeight="300">
   <Grid>
     <ScrollViewer>

--- a/Source/Examples/Avalonia/MemoryTest/Window2.axaml.cs
+++ b/Source/Examples/Avalonia/MemoryTest/Window2.axaml.cs
@@ -22,7 +22,6 @@ namespace MemoryTest
             }
 
             InitializeComponent();
-            App.AttachDevTools(this);
 
             DataContext = Plots;
         }

--- a/Source/Examples/Avalonia/SimpleDemo/App.axaml.cs
+++ b/Source/Examples/Avalonia/SimpleDemo/App.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using OxyPlot.Avalonia;
@@ -8,35 +9,37 @@ namespace SimpleDemo
 {
     class App : Application
     {
-        public App()
-        {
-            RegisterServices();
-        }
-
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
-            base.Initialize();
+#if DEBUG
+            this.AttachDeveloperTools();
+#endif
         }
 
         public override void OnFrameworkInitializationCompleted()
         {
-            if (!(ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop))
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                throw new PlatformNotSupportedException();
+                desktop.MainWindow = new MainWindow();
             }
 
-            desktop.MainWindow = new MainWindow();
-
             base.OnFrameworkInitializationCompleted();
+        }
+    }
+
+    public class Program
+    {
+        public static AppBuilder BuildAvaloniaApp()
+        {
+            OxyPlotModule.EnsureLoaded();
+            return AppBuilder.Configure<App>()
+                .UsePlatformDetect();
         }
 
         public static void Main(string[] args)
         {
-            OxyPlotModule.EnsureLoaded();
-            AppBuilder.Configure<App>()
-                .UsePlatformDetect()
-                .StartWithClassicDesktopLifetime(args);
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }
     }
 }

--- a/Source/Examples/Avalonia/SimpleDemo/MainWindow.axaml
+++ b/Source/Examples/Avalonia/SimpleDemo/MainWindow.axaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
         xmlns:oxy="clr-namespace:OxyPlot.Avalonia;assembly=OxyPlot.Avalonia" 
         xmlns:simpleDemo="clr-namespace:SimpleDemo;assembly=SimpleDemo"
+        x:DataType="simpleDemo:MainViewModel"
         Title="OxyPlot SimpleDemo" Height="480" Width="640">
     <Window.DataContext>
         <simpleDemo:MainViewModel />

--- a/Source/Examples/Avalonia/SimpleDemo/MainWindow.axaml.cs
+++ b/Source/Examples/Avalonia/SimpleDemo/MainWindow.axaml.cs
@@ -25,7 +25,6 @@ namespace SimpleDemo
         public MainWindow()
         {
             InitializeComponent();
-			this.AttachDevTools();
         }
 
         private void InitializeComponent()

--- a/Source/Examples/Avalonia/SimpleDemo/SimpleDemo.csproj
+++ b/Source/Examples/Avalonia/SimpleDemo/SimpleDemo.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup> 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <ProjectReference Include="..\..\..\OxyPlot.Avalonia\OxyPlot.Avalonia.csproj" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Simple" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/Source/OxyPlot.Avalonia/OxyPlot.Avalonia.csproj
+++ b/Source/OxyPlot.Avalonia/OxyPlot.Avalonia.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PackageId>Oxyplot.Avalonia</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>OxyPlot is a plotting library for .NET. This is a support library for OxyPlot to work with AvaloniaUI.</Description>

--- a/Source/OxyPlot.Avalonia/PlotBase.cs
+++ b/Source/OxyPlot.Avalonia/PlotBase.cs
@@ -8,6 +8,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using Avalonia.Reactive;
+using Avalonia.Input.Platform;
 
 namespace OxyPlot.Avalonia
 {

--- a/Source/OxyPlot.Avalonia/Themes/Default.axaml
+++ b/Source/OxyPlot.Avalonia/Themes/Default.axaml
@@ -1,7 +1,9 @@
-<Styles xmlns="https://github.com/avaloniaui" 
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:local="http://oxyplot.org/avalonia"
-        xmlns:converters="clr-namespace:OxyPlot.Avalonia.Converters">
+<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="clr-namespace:OxyPlot.Avalonia.Converters"
+    xmlns:local="http://oxyplot.org/avalonia"
+    xmlns:oxy="clr-namespace:OxyPlot;assembly=OxyPlot">
 
     <Style Selector="local|TrackerControl">
         <Setter Property="Background" Value="#E0FFFFA0" />
@@ -19,17 +21,31 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Canvas HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ClipToBounds="False">
-                        <Line Name="PART_HorizontalLine" IsVisible="{TemplateBinding HorizontalLineVisibility}"
-                  Stroke="{TemplateBinding LineStroke}"
-                  StrokeDashArray="{TemplateBinding LineDashArray}" />
-                        <Line Name="PART_VerticalLine" IsVisible="{TemplateBinding VerticalLineVisibility}"
-                  Stroke="{TemplateBinding LineStroke}"
-                  StrokeDashArray="{TemplateBinding LineDashArray}" />
+                    <Canvas
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        ClipToBounds="False">
+                        <Line
+                            Name="PART_HorizontalLine"
+                            IsVisible="{TemplateBinding HorizontalLineVisibility}"
+                            Stroke="{TemplateBinding LineStroke}"
+                            StrokeDashArray="{TemplateBinding LineDashArray}" />
+                        <Line
+                            Name="PART_VerticalLine"
+                            IsVisible="{TemplateBinding VerticalLineVisibility}"
+                            Stroke="{TemplateBinding LineStroke}"
+                            StrokeDashArray="{TemplateBinding LineDashArray}" />
                         <Panel Name="PART_ContentContainer" ClipToBounds="False">
-                            <Path Name="PART_Path" Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}"
-                    StrokeThickness="{TemplateBinding BorderThickness, Converter={x:Static converters:ThicknessConverter.Instance}}" />
-                            <ContentPresenter Name="PART_Content" Content="{TemplateBinding Content}" HorizontalAlignment="Center" />
+                            <Path
+                                Name="PART_Path"
+                                Fill="{TemplateBinding Background}"
+                                Stroke="{TemplateBinding BorderBrush}"
+                                StrokeThickness="{TemplateBinding BorderThickness,
+                                                                  Converter={x:Static converters:ThicknessConverter.Instance}}" />
+                            <ContentPresenter
+                                Name="PART_Content"
+                                HorizontalAlignment="Center"
+                                Content="{TemplateBinding Content}" />
                         </Panel>
                     </Canvas>
                 </ControlTemplate>
@@ -41,10 +57,10 @@
         <Setter Property="Background" Value="White" />
         <Setter Property="DefaultTrackerTemplate">
             <Setter.Value>
-                <ControlTemplate>
-                    <local:TrackerControl Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}">
+                <ControlTemplate x:DataType="oxy:TrackerHitResult">
+                    <local:TrackerControl LineExtents="{Binding PlotModel.PlotArea}" Position="{Binding Position}">
                         <local:TrackerControl.Content>
-                            <TextBlock Text="{Binding Text}" Margin="7" />
+                            <TextBlock Margin="7" Text="{Binding Text}" />
                         </local:TrackerControl.Content>
                     </local:TrackerControl>
                 </ControlTemplate>
@@ -53,15 +69,20 @@
         <Setter Property="ZoomRectangleTemplate">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle Fill="#40FFFF00" Stroke="Black" StrokeDashArray="3,1" />
+                    <Rectangle
+                        Fill="#40FFFF00"
+                        Stroke="Black"
+                        StrokeDashArray="3,1" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}">
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
                         <Panel Name="PART_Panel" />
                     </Border>
                 </ControlTemplate>
@@ -73,10 +94,10 @@
         <Setter Property="Background" Value="White" />
         <Setter Property="DefaultTrackerTemplate">
             <Setter.Value>
-                <ControlTemplate>
-                    <local:TrackerControl Position="{Binding Position}" LineExtents="{Binding PlotModel.PlotArea}">
+                <ControlTemplate x:DataType="oxy:TrackerHitResult">
+                    <local:TrackerControl LineExtents="{Binding PlotModel.PlotArea}" Position="{Binding Position}">
                         <local:TrackerControl.Content>
-                            <TextBlock Text="{Binding Text}" Margin="7" />
+                            <TextBlock Margin="7" Text="{Binding Text}" />
                         </local:TrackerControl.Content>
                     </local:TrackerControl>
                 </ControlTemplate>
@@ -85,15 +106,20 @@
         <Setter Property="ZoomRectangleTemplate">
             <Setter.Value>
                 <ControlTemplate>
-                    <Rectangle Fill="#40FFFF00" Stroke="Black" StrokeDashArray="3,1" />
+                    <Rectangle
+                        Fill="#40FFFF00"
+                        Stroke="Black"
+                        StrokeDashArray="3,1" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>
-                    <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}">
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}">
                         <Panel Name="PART_Panel" />
                     </Border>
                 </ControlTemplate>


### PR DESCRIPTION
This Pull Request updates OxyPlot.Avalonia to support Avalonia 12.0. It addresses breaking changes in the Avalonia API, specifically regarding compiled bindings, internal property changes, and the new diagnostics/developer tools infrastructure.

### Breaking Changes

- Projects using this version must target .NET 8 or higher to remain compatible with Avalonia 12.

- Users may need to install the AvaloniaUI.DiagnosticsSupport package to continue using the integrated developer tools.

### Testing Performed 

- Built and ran the included sample projects on both Windows 11 and Ubuntu.